### PR TITLE
Reload server browser on connect

### DIFF
--- a/src/views/afsBrowser.ts
+++ b/src/views/afsBrowser.ts
@@ -259,7 +259,7 @@ export function initializeAFSBrowser(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("arcad-afs-for-ibm-i.add.to.ifs.browser.server", (server: AFSServerItem) => server.addToIFSBrowser())
   );
 
-  Code4i.onEvent("connected", () => afsBrowser.refresh());
+  Code4i.onEvent("connected", () => afsBrowser.reload());
 }
 
 function getServerIcon(server: AFSServer): Icon {


### PR DESCRIPTION
Use `reload` instead of `refresh` when connecting to actually reload all the AFS starter's locations.