### PR TITLE
Updated for Code 4 i 2.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "axios": "^1.6.5"
       },
       "devDependencies": {
-        "@halcyontech/vscode-ibmi-types": "^2.6",
+        "@halcyontech/vscode-ibmi-types": "^2.6.3",
         "@types/node": "18.x",
         "@types/vscode": "^1.84.0",
         "@typescript-eslint/eslint-plugin": "^6.9.0",
@@ -473,9 +473,9 @@
       }
     },
     "node_modules/@halcyontech/vscode-ibmi-types": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@halcyontech/vscode-ibmi-types/-/vscode-ibmi-types-2.6.1.tgz",
-      "integrity": "sha512-oEIPj1eyuyGVXqEiUBc0LIyg5Zv0hgEv90YAbmipsJ19YoCpm1MNsMl2cPmxVPPlyi8V13xptdZ8gABuTvlVRw==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@halcyontech/vscode-ibmi-types/-/vscode-ibmi-types-2.6.3.tgz",
+      "integrity": "sha512-XnAgGCm36+ee+6TG6SqCEGMJeCu3JMS9qRrfd+mg3mHMCfbvAxplLTpRPSFocgfUDJT1W8cWft30XSNjylM4Uw==",
       "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -282,7 +282,7 @@
     "nls": "npx @vscode/l10n-dev export --outDir ./l10n ./src"
   },
   "devDependencies": {
-    "@halcyontech/vscode-ibmi-types": "^2.6",
+    "@halcyontech/vscode-ibmi-types": "^2.6.3",
     "@types/node": "18.x",
     "@types/vscode": "^1.84.0",
     "@typescript-eslint/eslint-plugin": "^6.9.0",

--- a/src/code4i.ts
+++ b/src/code4i.ts
@@ -1,4 +1,4 @@
-import { CodeForIBMi, IBMiEvent, QsysFsOptions } from "@halcyontech/vscode-ibmi-types";
+import { CodeForIBMi, IBMiEvent, OpenEditableOptions } from "@halcyontech/vscode-ibmi-types";
 import vscode from "vscode";
 
 let codeForIBMi: CodeForIBMi;
@@ -47,7 +47,7 @@ export namespace Code4i {
     return codeForIBMi.tools.makeid();
   }
 
-  export function open(path: string, options?: QsysFsOptions) {
-    vscode.commands.executeCommand("code-for-ibmi.openEditable", path, 0, options);
+  export function open(path: string, options?: OpenEditableOptions) {
+    vscode.commands.executeCommand("code-for-ibmi.openEditable", path, options);
   }
 }


### PR DESCRIPTION
The `openEditable` command now take `OpenEditableOptions` in parameter.