### PR TITLE
Protect actions when server is running

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,12 +252,12 @@
         },
         {
           "command": "arcad-afs-for-ibm-i.clear.logs.server",
-          "when": "view == afsServerBrowser && viewItem =~ /^afsserver.*$/",
+          "when": "view == afsServerBrowser && viewItem == afsserver",
           "group": "03_afsserveractions@01"
         },
         {
           "command": "arcad-afs-for-ibm-i.clear.configuration.server",
-          "when": "view == afsServerBrowser && viewItem =~ /^afsserver.*$/",
+          "when": "view == afsServerBrowser && viewItem == afsserver",
           "group": "03_afsserveractions@02"
         },
         {

--- a/src/dao/serverDAO.ts
+++ b/src/dao/serverDAO.ts
@@ -136,11 +136,11 @@ export namespace ServerDAO {
   }
 
   export async function openConfiguration(server: AFSServer) {
-    Code4i.open(`${server.ifsPath}/configuration/osgi.cm.ini`);
+    Code4i.open(`${server.ifsPath}/configuration/osgi.cm.ini`, { readonly: server.running });
   }
 
   export async function clearConfiguration(server: AFSServer) {
-    return await vscode.window.withProgress({title: l10n.t("Clearing {0} configuration area...", server.name), location: vscode.ProgressLocation.Notification}, async () => {
+    return await vscode.window.withProgress({ title: l10n.t("Clearing {0} configuration area...", server.name), location: vscode.ProgressLocation.Notification }, async () => {
       const configurationDirectory = `${server.ifsPath}/configuration`;
       return withTempDirectory(`${Code4i.getConnection().config?.tempDir}/arcadserver_${server.name}`, async tempDirectory => {
         const clearCommand = [
@@ -158,11 +158,11 @@ export namespace ServerDAO {
           return false;
         }
       });
-    });    
+    });
   }
 
   export async function clearLogs(server: AFSServer) {
-    return await vscode.window.withProgress({title: l10n.t("Clearing {0} logs...", server.name), location: vscode.ProgressLocation.Notification}, async () => {
+    return await vscode.window.withProgress({ title: l10n.t("Clearing {0} logs...", server.name), location: vscode.ProgressLocation.Notification }, async () => {
       const clearResult = await Code4i.runShellCommand(`rm -rf ${server.ifsPath}/logs/*`);
       if (clearResult.code === 0) {
         vscode.window.showInformationMessage(l10n.t("ARCAD Server {0} logs were successfully cleared.", server.name));
@@ -172,7 +172,7 @@ export namespace ServerDAO {
         vscode.window.showErrorMessage(l10n.t("Failed to clear {0} logs: {1}", server.name, clearResult.stderr));
         return false;
       }
-    });    
+    });
   }
 
   export async function install(installationPackage: vscode.Uri, properties: InstallationProperties) {

--- a/src/views/afsBrowser.ts
+++ b/src/views/afsBrowser.ts
@@ -104,7 +104,7 @@ class AFSServerItem extends AFSBrowserItem {
       icon: getServerIcon(server),
       state: vscode.TreeItemCollapsibleState.None
     });
-    this.contextValue = `afsserver_${server.running ? "run" : ""}`;
+    this.contextValue = `afsserver${server.running ? "_run" : ""}`;
     this.description = server.running ? l10n.t("Running") : l10n.t("Stopped");
     this.tooltip = new vscode.MarkdownString(`- ${l10n.t("IFS path")}: ${server.ifsPath}\n`, false);
     if (server.configuration.rest?.port) {


### PR DESCRIPTION
- `Clear...` actions are only available when the server is stopped
- Opening the configuration will be read-only if the server is running