### PR TITLE
Added access to online help from within VSCode

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,109 +41,115 @@
       {
         "command": "arcad-afs-for-ibm-i.refresh",
         "title": "%refresh%",
-        "category": "ARCAD AFS for IBM i",
+        "category": "ARCAD Servers",
         "icon": "$(refresh)"
       },
       {
         "command": "arcad-afs-for-ibm-i.reload",
         "title": "%reload%",
-        "category": "ARCAD AFS for IBM i",
+        "category": "ARCAD Servers",
         "icon": "$(sync)"
       },
       {
         "command": "arcad-afs-for-ibm-i.start.server",
         "title": "%start%",
-        "category": "ARCAD AFS for IBM i",
+        "category": "ARCAD Servers",
         "icon": "$(play)"
       },
       {
         "command": "arcad-afs-for-ibm-i.debug.server",
         "title": "%debug%",
-        "category": "ARCAD AFS for IBM i",
+        "category": "ARCAD Servers",
         "icon": "$(debug-alt)"
       },
       {
         "command": "arcad-afs-for-ibm-i.stop.server",
         "title": "%stop%",
-        "category": "ARCAD AFS for IBM i",
+        "category": "ARCAD Servers",
         "icon": "$(debug-stop)"
       },
       {
         "command": "arcad-afs-for-ibm-i.edit.server",
         "title": "%edit%",
-        "category": "ARCAD AFS for IBM i"
+        "category": "ARCAD Servers"
       },
       {
         "command": "arcad-afs-for-ibm-i.show.server",
         "title": "%show%",
-        "category": "ARCAD AFS for IBM i"
+        "category": "ARCAD Servers"
       },
       {
         "command": "arcad-afs-for-ibm-i.delete.server",
         "title": "%delete%",
-        "category": "ARCAD AFS for IBM i"
+        "category": "ARCAD Servers"
       },
       {
         "command": "arcad-afs-for-ibm-i.open.logs.server",
         "title": "%open.logs%",
-        "category": "ARCAD AFS for IBM i"
+        "category": "ARCAD Servers"
       },
       {
         "command": "arcad-afs-for-ibm-i.open.configuration.server",
         "title": "%open.configuration%",
-        "category": "ARCAD AFS for IBM i"
+        "category": "ARCAD Servers"
       },
       {
         "command": "arcad-afs-for-ibm-i.add.to.ifs.browser.server",
         "title": "%add.to.ifs.browser%",
-        "category": "ARCAD AFS for IBM i"
+        "category": "ARCAD Servers"
       },
       {
         "command": "arcad-afs-for-ibm-i.clear.configuration.server",
         "title": "%clear.configuration%",
-        "category": "ARCAD AFS for IBM i"
+        "category": "ARCAD Servers"
       },
       {
         "command": "arcad-afs-for-ibm-i.clear.logs.server",
         "title": "%clear.logs%",
-        "category": "ARCAD AFS for IBM i"
+        "category": "ARCAD Servers"
       },
       {
         "command": "arcad-afs-for-ibm-i.install",
         "title": "%install%",
-        "category": "ARCAD AFS for IBM i",
+        "category": "ARCAD Servers",
         "icon": "$(add)"
       },
       {
         "command": "arcad-afs-for-ibm-i.install.server",
         "title": "%install.server%",
-        "category": "ARCAD AFS for IBM i",
+        "category": "ARCAD Servers",
         "icon": "$(add)"
       },
       {
         "command": "arcad-afs-for-ibm-i.update.server",
         "title": "%update%",
-        "category": "ARCAD AFS for IBM i"
+        "category": "ARCAD Servers"
       },
       {
         "command": "arcad-afs-for-ibm-i.install.war",
         "title": "%install.war%",
-        "category": "ARCAD AFS for IBM i"
+        "category": "ARCAD Servers"
       },
       {
         "command": "arcad-afs-for-ibm-i.open.browser",
         "title": "%open.browser%",
-        "category": "ARCAD AFS for IBM i"
+        "category": "ARCAD Servers"
       },
       {
         "command": "arcad-afs-for-ibm-i.open.config.http",
         "title": "%open.http.config%",
-        "category": "ARCAD AFS for IBM i"
+        "category": "ARCAD Servers"
       },
       {
         "command": "arcad-afs-for-ibm-i.open.config.https",
         "title": "%open.https.config%",
-        "category": "ARCAD AFS for IBM i"
+        "category": "ARCAD Servers"
+      },
+      {
+        "command": "arcad-afs-for-ibm-i.open.online.help",
+        "icon":"$(question)",
+        "title": "%open.online.help%",
+        "category": "ARCAD Servers"
       }
     ],
     "views": {
@@ -253,6 +259,11 @@
         }
       ],       
       "view/title": [
+        {
+          "command": "arcad-afs-for-ibm-i.open.online.help",
+          "group": "navigation@00",
+          "when": "view == afsServerBrowser"
+        },
         {
           "command": "arcad-afs-for-ibm-i.install",
           "group": "navigation@01",

--- a/package.nls.json
+++ b/package.nls.json
@@ -19,5 +19,6 @@
   "show": "Show server information",
   "start": "Start",
   "stop": "Stop",
-  "update": "Update"
+  "update": "Update",
+  "open.online.help":"Open online help"
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,9 @@ import { initializeAFSBrowser } from './views/serversBrowser';
 export async function activate(context: vscode.ExtensionContext) {
 	await Code4i.initialize();
 	initializeAFSBrowser(context);
+	context.subscriptions.push(
+		vscode.commands.registerCommand("arcad-afs-for-ibm-i.open.online.help", () => vscode.commands.executeCommand("vscode.open","https://arcad-software.github.io/arcad-ibmi-servers"))
+	);
 }
 
 export function deactivate() {


### PR DESCRIPTION
This PR adds two ways to access the extension's online help from VSCode:
- From the command palette
![image](https://github.com/ARCAD-Software/arcad-ibmi-servers/assets/11096890/692efa97-c0ed-489d-bd11-cd9853cc05ff)

- From the ARCAD Servers view title bar
![image](https://github.com/ARCAD-Software/arcad-ibmi-servers/assets/11096890/af8a64ee-3f24-4117-bebe-8493115c0e33)
