### PR TITLE
Show AFS ports numbers in editor

### DIFF
--- a/src/editors/afs/show.ts
+++ b/src/editors/afs/show.ts
@@ -13,6 +13,8 @@ export async function openShowAFSServerEditor(server: AFSServer) {
        ${addRow(l10n.t("Java home"), `${server.javaHome}`)}
        ${addRow(l10n.t("Java properties"), `${server.javaProps}`)}
        ${addRow(l10n.t("Running"), `${server.running ? l10n.t("Yes") : l10n.t("No")}`)}
+       ${addRow(l10n.t("HTTP port"), `${server.configuration.rest?.port || '-'}`)}
+       ${addRow(l10n.t("HTTPS port"), `${server.configuration.rest?.portssl || '-'}`)}
     </table>`);
   const tabs: ComplexTab[] = [{ label: l10n.t("{0} instance", server.name), fields: instanceSection.fields }];
 
@@ -51,7 +53,7 @@ export async function openShowAFSServerEditor(server: AFSServer) {
         ${addRow(l10n.t("Job queue"), `${job.JOB_QUEUE_LIBRARY}/${job.JOB_QUEUE_NAME}`)}
         ${addRow(l10n.t("Entered system on"), job.JOB_ENTERED_SYSTEM_TIME)}
         ${addRow(l10n.t("Active on"), job.JOB_ACTIVE_TIME)}
-        ${addRow(l10n.t("Pick temporary storage"), job.PEAK_TEMPORARY_STORAGE)}
+        ${addRow(l10n.t("Peack temporary storage"), job.PEAK_TEMPORARY_STORAGE)}
         ${addRow(l10n.t("CCSID"), job.CCSID)}
         ${addRow(l10n.t("Language ID"), job.LANGUAGE_ID)}
         ${addRow(l10n.t("Country ID"), job.COUNTRY_ID)}

--- a/src/editors/jetty/show.ts
+++ b/src/editors/jetty/show.ts
@@ -33,7 +33,7 @@ export async function openShowJettyServerEditor(server: JettyServer) {
         ${addRow(l10n.t("Job queue"), `${job.JOB_QUEUE_LIBRARY}/${job.JOB_QUEUE_NAME}`)}
         ${addRow(l10n.t("Entered system on"), job.JOB_ENTERED_SYSTEM_TIME)}
         ${addRow(l10n.t("Active on"), job.JOB_ACTIVE_TIME)}
-        ${addRow(l10n.t("Pick temporary storage"), job.PEAK_TEMPORARY_STORAGE)}
+        ${addRow(l10n.t("Peack temporary storage"), job.PEAK_TEMPORARY_STORAGE)}
         ${addRow(l10n.t("CCSID"), job.CCSID)}
         ${addRow(l10n.t("Language ID"), job.LANGUAGE_ID)}
         ${addRow(l10n.t("Country ID"), job.COUNTRY_ID)}


### PR DESCRIPTION
This PR adds the port numbers in the editor when showing information about an AFS server.
![image](https://github.com/ARCAD-Software/arcad-ibmi-servers/assets/11096890/290e9cf4-8a2f-45f8-bd93-5c59101e5111)
