### PR TITLE
Add suport for displaying ARCAD instances

### DIFF
--- a/src/dao/arcadDAO.ts
+++ b/src/dao/arcadDAO.ts
@@ -1,0 +1,37 @@
+//01 M MACROMAKER Process Manager : MMLICPGM   MMNBUSR    MMTYPCLE   MMDATLIM   MMAVERT    *NOTCHK
+//02 M REPOSITORY Open Repository : AROLICPGM  ARONBUSR   AROTYPCLE  ARODATLIM  AROAVERT   *NOTCHK
+//03 M            Skipper/Builder
+//04 S ARCAD_CM     Full dev.seat : ARLICPGM   ARNBDEV    ARTYPCLE   ARDATLIM   ARAVERT
+//05 S ARCAD_ADL    Interf.ADELIA : ARALICPGM             ARATYPCLE  ARADATLIM  ARAAVERT
+//07 M ARCAD_INT  Integrater. . . : INLICPGM              INTYPCLE   INDATLIM   INAVERT
+//08 M ARCAD_DLV  Deliver . . . . : DLLICPGM              DLTYPCLE   DLDATLIM   DLAVERT
+//09 M ARCAD_DTC  Data Changer. . : ARTLICPGM             ARTTYPCLE  ARTDATLIM  ARTAVERT
+//10 M ARCAD_FRM  Transformer Fld : FRLICPGM              FRTYPCLE   FRDATLIM   FRAVERT
+//11 M TRANSF_DB  Transformer DB  : TDBLICPGM             TDBTYPCLE  TDBDATLIM  TDBAVERT
+//12 M TRANSF_CAS Transform. Case : TFCLICPGM             TFCTYPCLE  TFCDATLIM  TFCAVERT
+//14 M VERIFIER   Verifier  . . . : OBVLICPGM  OBVNBDEV   OBVTYPCLE  OBVDATLIM  OBVAVERT
+//15 M OBSERVER   Observer  . . . : OBSLICPGM  OBSNBDEV   OBSTYPCLE  OBSDATLIM  OBSAVERT
+//16
+//17 M CLOUDKYSRV Cloud Key Serv. : CKSLICPGM             CKSTYPCLE  CKSDATLIM  CKSAVERT
+
+import { Code4i } from "../code4i";
+import { ArcadInstance } from "../types";
+
+export namespace ArcadDAO {
+  export async function loadInstances() {
+    const instances = await Code4i.runSQL(
+      `Select INS_JCODE, INS_CTXT, INS_JPRDL, INS_NASPNB, DATA_AREA_VALUE ` +
+      `From ARCAD_SYS.AARCINSF1 ` +
+      `Cross Join Table(QSYS2.DATA_AREA_INFO( DATA_AREA_NAME => 'ARCVERSION', DATA_AREA_LIBRARY => INS_JPRDL)) ` +
+      `Order by INS_JCODE`
+    );
+
+    return instances.map(instance => ({
+      code: String(instance.INS_JCODE).trim(),
+      text: String(instance.INS_CTXT).trim(),
+      library: String(instance.INS_JPRDL).trim(),
+      iasp: instance.INS_NASPNB && instance.INS_NASPNB !== '1' ? String(instance.INS_NASPNB).trim() : undefined,
+      version: String(instance.DATA_AREA_VALUE).trim(),
+    }) as ArcadInstance);
+  }
+}

--- a/src/dao/commonDAO.ts
+++ b/src/dao/commonDAO.ts
@@ -64,5 +64,5 @@ export namespace CommonDAO {
       }
     });
     return props;
-  }
+  }  
 }

--- a/src/editors/afs/show.ts
+++ b/src/editors/afs/show.ts
@@ -3,6 +3,7 @@ import vscode, { l10n } from "vscode";
 import { Code4i } from "../../code4i";
 import { AFSServerDAO } from "../../dao/afsDAO";
 import { AFSServer } from "../../types";
+import { addRow, capitalize } from "../editor-utils";
 
 export async function openShowAFSServerEditor(server: AFSServer) {
   const instanceSection = Code4i.customUI()
@@ -69,22 +70,4 @@ export async function openShowAFSServerEditor(server: AFSServer) {
   }
 
   Code4i.customUI().addComplexTabs(tabs).loadPage(l10n.t("Show {0}", server.name));
-}
-
-function addRow(key: string, value?: any) {
-  if (value !== undefined) {
-    return /*html*/ `<tr>
-      <td><vscode-label>${key}:</vscode-label></td>
-      <td>${value}</td>
-    </tr>`;
-  }
-  else {
-    return /*html*/ `<tr>
-      <td colspan="2"><h3><u>${key}</u></h3></td>
-    </tr>`;
-  }
-}
-
-function capitalize(text: string) {
-  return text[0].toUpperCase() + text.substring(1);
 }

--- a/src/editors/arcad/show.ts
+++ b/src/editors/arcad/show.ts
@@ -1,90 +1,42 @@
-import { ComplexTab } from "@halcyontech/vscode-ibmi-types/api/CustomUI";
 import vscode, { l10n } from "vscode";
 import { Code4i } from "../../code4i";
-import { AFSServerDAO } from "../../dao/afsDAO";
-import { AFSServer } from "../../types";
+import { ArcadDAO } from "../../dao/arcadDAO";
+import { ArcadInstance, ArcadLicense } from "../../types";
+import { addRow } from "../editor-utils";
 
-export async function openShowAFSServerEditor(server: AFSServer) {
-  const instanceSection = Code4i.customUI()
+export async function openShowArcadInstanceEditor(instance: ArcadInstance) {
+  const licenses = await vscode.window.withProgress({ title: l10n.t("Gathering instance {0} licenses...", instance.code), location: vscode.ProgressLocation.Notification },
+    async () => ArcadDAO.readLicenses(instance));
+
+  Code4i.customUI()
     .addParagraph(`<table>
-       ${addRow(l10n.t("IFS path"), server.ifsPath)}
-       ${addRow(l10n.t("Job queue"), `${server.jobqLibrary}/${server.jobqName}`)}
-       ${addRow(l10n.t("Job user"), `${server.user}`)}
-       ${addRow(l10n.t("Java home"), `${server.javaHome}`)}
-       ${addRow(l10n.t("Java properties"), `${server.javaProps}`)}
-       ${addRow(l10n.t("Running"), `${server.running ? l10n.t("Yes") : l10n.t("No")}`)}
-       ${addRow(l10n.t("HTTP port"), `${server.configuration.rest?.port || '-'}`)}
-       ${addRow(l10n.t("HTTPS port"), `${server.configuration.rest?.portssl || '-'}`)}
-    </table>`);
-  const tabs: ComplexTab[] = [{ label: l10n.t("{0} instance", server.name), fields: instanceSection.fields }];
-
-  if (server.running) {
-    await vscode.window.withProgress({ title: l10n.t("Gathering {0} runtime information...", server.name), location: vscode.ProgressLocation.Notification }, async () => {
-      const about = (await AFSServerDAO.get<any>(server, "/about"))?.about;
-      if (about) {
-        const toString = (object: any, tab?: boolean): string =>
-          Object.entries(object).map(([key, value]) => {
-            key = capitalize(key);
-            if (typeof value === "object") {
-              return `${addRow(key)}${toString(value, true)}`;
-            }
-            else {
-              return addRow(`${tab ? "&nbsp;&nbsp;&nbsp;" : ""}${key}`, value);
-            }
-          }).join("");
-
-        const aboutSection = Code4i.customUI().addParagraph(`<table>${toString(about)}</table>`);
-        tabs.push({ label: l10n.t("About"), fields: aboutSection.fields });
-      }
-
-      const [job] = await Code4i.runSQL(`Select * From Table(QSYS2.JOB_INFO(` +
-        `JOB_USER_FILTER => '${server.user}', ` +
-        `JOB_STATUS_FILTER => '*ACTIVE', ` +
-        `JOB_TYPE_FILTER => '*BATCH')) ` +
-        `Where JOB_NAME = '${server.jobNumber}/${server.jobUser}/${server.jobName}'`
-      );
-      const jobSection = Code4i.customUI()
-        .addParagraph(`<table>
-        ${addRow(l10n.t("Name"), job.JOB_NAME)}
-        ${addRow(l10n.t("Type"), job.JOB_TYPE_ENHANCED)}
-        ${addRow(l10n.t("Status"), job.JOB_STATUS)}        
-        ${addRow(l10n.t("Subsystem"), job.JOB_SUBSYSTEM)}
-        ${addRow(l10n.t("Job description"), `${job.JOB_DESCRIPTION_LIBRARY}/${job.JOB_DESCRIPTION}`)}
-        ${addRow(l10n.t("Job queue"), `${job.JOB_QUEUE_LIBRARY}/${job.JOB_QUEUE_NAME}`)}
-        ${addRow(l10n.t("Entered system on"), job.JOB_ENTERED_SYSTEM_TIME)}
-        ${addRow(l10n.t("Active on"), job.JOB_ACTIVE_TIME)}
-        ${addRow(l10n.t("Peack temporary storage"), job.PEAK_TEMPORARY_STORAGE)}
-        ${addRow(l10n.t("CCSID"), job.CCSID)}
-        ${addRow(l10n.t("Language ID"), job.LANGUAGE_ID)}
-        ${addRow(l10n.t("Country ID"), job.COUNTRY_ID)}
-        ${addRow(l10n.t("Date format"), job.DATE_FORMAT)}
-        ${addRow(l10n.t("Date separator"), job.DATE_SEPARATOR)}
-        ${addRow(l10n.t("Time separator"), job.TIME_SEPARATOR)}
-        ${addRow(l10n.t("Logging level"), job.MESSAGE_LOGGING_LEVEL)}
-        ${addRow(l10n.t("Logging severity"), job.MESSAGE_LOGGING_SEVERITY)}
-        ${addRow(l10n.t("Logging text"), job.MESSAGE_LOGGING_TEXT)}
-      </table>`);
-      tabs.push({ label: l10n.t("Current job"), fields: jobSection.fields });
-    });
-  }
-
-  Code4i.customUI().addComplexTabs(tabs).loadPage(l10n.t("Show {0}", server.name));
+       ${addRow(l10n.t("Code"), instance.code)}
+       ${addRow(l10n.t("Version"), instance.version)}
+       ${addRow(l10n.t("Description"), instance.text)}
+       ${addRow(l10n.t("Production library"), instance.library)}       
+       ${addRow(l10n.t("IASP"), instance.iasp || '*SYSBAS')}
+    </table>`)
+    .addParagraph(`<vscode-table zebra min-column-width="5" columns='["300px"]'>
+    <vscode-table-header slot="header">
+      <vscode-table-header-cell>${l10n.t("Product")}</vscode-table-header-cell>
+      <vscode-table-header-cell>${l10n.t("Key")}</vscode-table-header-cell>
+      <vscode-table-header-cell>${l10n.t("Type")}</vscode-table-header-cell>
+      <vscode-table-header-cell>${l10n.t("Count")}</vscode-table-header-cell>
+      <vscode-table-header-cell>${l10n.t("Limit")}</vscode-table-header-cell>
+    </vscode-table-header>
+    <vscode-table-body slot="body">
+      ${licenses.map(license => addLicenseRow(license)).join("")}
+    </vscode-table-body>
+  </vscode-table>`)
+    .loadPage(l10n.t("ARCAD instance {0}", instance.code));
 }
 
-function addRow(key: string, value?: any) {
-  if (value !== undefined) {
-    return /*html*/ `<tr>
-      <td><vscode-label>${key}:</vscode-label></td>
-      <td>${value}</td>
-    </tr>`;
-  }
-  else {
-    return /*html*/ `<tr>
-      <td colspan="2"><h3><u>${key}</u></h3></td>
-    </tr>`;
-  }
-}
-
-function capitalize(text: string) {
-  return text[0].toUpperCase() + text.substring(1);
+function addLicenseRow(license: ArcadLicense) {
+  return `<vscode-table-row>
+    <vscode-table-cell>${license.name}</vscode-table-cell>
+    <vscode-table-cell>${license.license}</vscode-table-cell>
+    <vscode-table-cell>${license.type === "D" ? l10n.t("Permanent") : l10n.t("Temporary")}</vscode-table-cell>
+    <vscode-table-cell>${license.count > -1 ? `${license.count}` : '-'}</vscode-table-cell>
+    <vscode-table-cell>${license.type === "T" ? license.limit : '-'}</vscode-table-cell>    
+  </vscode-table-row>`;
 }

--- a/src/editors/arcad/show.ts
+++ b/src/editors/arcad/show.ts
@@ -1,0 +1,90 @@
+import { ComplexTab } from "@halcyontech/vscode-ibmi-types/api/CustomUI";
+import vscode, { l10n } from "vscode";
+import { Code4i } from "../../code4i";
+import { AFSServerDAO } from "../../dao/afsDAO";
+import { AFSServer } from "../../types";
+
+export async function openShowAFSServerEditor(server: AFSServer) {
+  const instanceSection = Code4i.customUI()
+    .addParagraph(`<table>
+       ${addRow(l10n.t("IFS path"), server.ifsPath)}
+       ${addRow(l10n.t("Job queue"), `${server.jobqLibrary}/${server.jobqName}`)}
+       ${addRow(l10n.t("Job user"), `${server.user}`)}
+       ${addRow(l10n.t("Java home"), `${server.javaHome}`)}
+       ${addRow(l10n.t("Java properties"), `${server.javaProps}`)}
+       ${addRow(l10n.t("Running"), `${server.running ? l10n.t("Yes") : l10n.t("No")}`)}
+       ${addRow(l10n.t("HTTP port"), `${server.configuration.rest?.port || '-'}`)}
+       ${addRow(l10n.t("HTTPS port"), `${server.configuration.rest?.portssl || '-'}`)}
+    </table>`);
+  const tabs: ComplexTab[] = [{ label: l10n.t("{0} instance", server.name), fields: instanceSection.fields }];
+
+  if (server.running) {
+    await vscode.window.withProgress({ title: l10n.t("Gathering {0} runtime information...", server.name), location: vscode.ProgressLocation.Notification }, async () => {
+      const about = (await AFSServerDAO.get<any>(server, "/about"))?.about;
+      if (about) {
+        const toString = (object: any, tab?: boolean): string =>
+          Object.entries(object).map(([key, value]) => {
+            key = capitalize(key);
+            if (typeof value === "object") {
+              return `${addRow(key)}${toString(value, true)}`;
+            }
+            else {
+              return addRow(`${tab ? "&nbsp;&nbsp;&nbsp;" : ""}${key}`, value);
+            }
+          }).join("");
+
+        const aboutSection = Code4i.customUI().addParagraph(`<table>${toString(about)}</table>`);
+        tabs.push({ label: l10n.t("About"), fields: aboutSection.fields });
+      }
+
+      const [job] = await Code4i.runSQL(`Select * From Table(QSYS2.JOB_INFO(` +
+        `JOB_USER_FILTER => '${server.user}', ` +
+        `JOB_STATUS_FILTER => '*ACTIVE', ` +
+        `JOB_TYPE_FILTER => '*BATCH')) ` +
+        `Where JOB_NAME = '${server.jobNumber}/${server.jobUser}/${server.jobName}'`
+      );
+      const jobSection = Code4i.customUI()
+        .addParagraph(`<table>
+        ${addRow(l10n.t("Name"), job.JOB_NAME)}
+        ${addRow(l10n.t("Type"), job.JOB_TYPE_ENHANCED)}
+        ${addRow(l10n.t("Status"), job.JOB_STATUS)}        
+        ${addRow(l10n.t("Subsystem"), job.JOB_SUBSYSTEM)}
+        ${addRow(l10n.t("Job description"), `${job.JOB_DESCRIPTION_LIBRARY}/${job.JOB_DESCRIPTION}`)}
+        ${addRow(l10n.t("Job queue"), `${job.JOB_QUEUE_LIBRARY}/${job.JOB_QUEUE_NAME}`)}
+        ${addRow(l10n.t("Entered system on"), job.JOB_ENTERED_SYSTEM_TIME)}
+        ${addRow(l10n.t("Active on"), job.JOB_ACTIVE_TIME)}
+        ${addRow(l10n.t("Peack temporary storage"), job.PEAK_TEMPORARY_STORAGE)}
+        ${addRow(l10n.t("CCSID"), job.CCSID)}
+        ${addRow(l10n.t("Language ID"), job.LANGUAGE_ID)}
+        ${addRow(l10n.t("Country ID"), job.COUNTRY_ID)}
+        ${addRow(l10n.t("Date format"), job.DATE_FORMAT)}
+        ${addRow(l10n.t("Date separator"), job.DATE_SEPARATOR)}
+        ${addRow(l10n.t("Time separator"), job.TIME_SEPARATOR)}
+        ${addRow(l10n.t("Logging level"), job.MESSAGE_LOGGING_LEVEL)}
+        ${addRow(l10n.t("Logging severity"), job.MESSAGE_LOGGING_SEVERITY)}
+        ${addRow(l10n.t("Logging text"), job.MESSAGE_LOGGING_TEXT)}
+      </table>`);
+      tabs.push({ label: l10n.t("Current job"), fields: jobSection.fields });
+    });
+  }
+
+  Code4i.customUI().addComplexTabs(tabs).loadPage(l10n.t("Show {0}", server.name));
+}
+
+function addRow(key: string, value?: any) {
+  if (value !== undefined) {
+    return /*html*/ `<tr>
+      <td><vscode-label>${key}:</vscode-label></td>
+      <td>${value}</td>
+    </tr>`;
+  }
+  else {
+    return /*html*/ `<tr>
+      <td colspan="2"><h3><u>${key}</u></h3></td>
+    </tr>`;
+  }
+}
+
+function capitalize(text: string) {
+  return text[0].toUpperCase() + text.substring(1);
+}

--- a/src/editors/arcad/show.ts
+++ b/src/editors/arcad/show.ts
@@ -21,7 +21,7 @@ export async function openShowArcadInstanceEditor(instance: ArcadInstance) {
       <vscode-table-header-cell>${l10n.t("Product")}</vscode-table-header-cell>
       <vscode-table-header-cell>${l10n.t("Key")}</vscode-table-header-cell>
       <vscode-table-header-cell>${l10n.t("Type")}</vscode-table-header-cell>
-      <vscode-table-header-cell>${l10n.t("Count")}</vscode-table-header-cell>
+      <vscode-table-header-cell>${l10n.t("Licenses")}</vscode-table-header-cell>
       <vscode-table-header-cell>${l10n.t("Limit")}</vscode-table-header-cell>
     </vscode-table-header>
     <vscode-table-body slot="body">

--- a/src/editors/editor-utils.ts
+++ b/src/editors/editor-utils.ts
@@ -1,0 +1,17 @@
+export function addRow(key: string, value?: any) {
+  if (value !== undefined) {
+    return /*html*/ `<tr>
+      <td><vscode-label>${key}:</vscode-label></td>
+      <td>${value}</td>
+    </tr>`;
+  }
+  else {
+    return /*html*/ `<tr>
+      <td colspan="2"><h3><u>${key}</u></h3></td>
+    </tr>`;
+  }
+}
+
+export function capitalize(text: string) {
+  return text[0].toUpperCase() + text.substring(1);
+}

--- a/src/editors/jetty/show.ts
+++ b/src/editors/jetty/show.ts
@@ -2,6 +2,7 @@ import { ComplexTab } from "@halcyontech/vscode-ibmi-types/api/CustomUI";
 import vscode, { l10n } from "vscode";
 import { Code4i } from "../../code4i";
 import { JettyServer } from "../../types";
+import { addRow } from "../editor-utils";
 
 export async function openShowJettyServerEditor(server: JettyServer) {
   const instanceSection = Code4i.customUI()
@@ -49,18 +50,4 @@ export async function openShowJettyServerEditor(server: JettyServer) {
   }
 
   Code4i.customUI().addComplexTabs(tabs).loadPage(l10n.t("Show Jetty {0}", server.library));
-}
-
-function addRow(key: string, value?: any) {
-  if (value !== undefined) {
-    return /*html*/ `<tr>
-      <td><vscode-label>${key}:</vscode-label></td>
-      <td>${value}</td>
-    </tr>`;
-  }
-  else {
-    return /*html*/ `<tr>
-      <td colspan="2"><h3><u>${key}</u></h3></td>
-    </tr>`;
-  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,3 +65,12 @@ export type ArcadInstance = {
   library:string
   iasp?:string
 };
+
+export type ArcadLicense = {
+  name: string
+  license: string
+  count: number
+  type: "T" | "D"
+  limit: string
+  warning: string
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,3 +57,11 @@ export type AFSServerUpdate = {
 };
 
 export type InstallationProperties = Map<string, string>;
+
+export type ArcadInstance = {
+  code:string
+  text:string  
+  version:string
+  library:string
+  iasp?:string
+};

--- a/src/views/serversBrowser.ts
+++ b/src/views/serversBrowser.ts
@@ -7,6 +7,7 @@ import { JettyDAO } from "../dao/jettyDAO";
 import { openEditAFSServerEditor } from "../editors/afs/edit";
 import { openInstallAFSEditor } from "../editors/afs/install";
 import { openShowAFSServerEditor } from "../editors/afs/show";
+import { openShowArcadInstanceEditor } from "../editors/arcad/show";
 import { openInstallJettyEditor } from "../editors/jetty/install";
 import { openShowJettyServerEditor } from "../editors/jetty/show";
 import { AFSServer, ArcadInstance, JettyServer, ServerLocation } from "../types";
@@ -122,12 +123,22 @@ class ArcadInstancesItem extends ServerBrowserItem {
 
 class ArcadInstanceItem extends ServerBrowserItem {
   constructor(parent: ArcadInstancesItem, readonly instance: ArcadInstance) {
-    super(instance.code, { icon: { name: "circle" }, state: vscode.TreeItemCollapsibleState.None, parent });
+    super(instance.code, { icon: { name: "circle-filled" }, state: vscode.TreeItemCollapsibleState.None, parent });
     this.contextValue = "arcadinstance";
     this.description = `${instance.version} - ${instance.text}`;
     this.tooltip = new vscode.MarkdownString(`${instance.text}\n`)
       .appendMarkdown(`- ${l10n.t("Production library")}: ${instance.library}\n`)
       .appendMarkdown(`- iASP: ${instance.iasp || '*SYSBAS'}`);
+
+    this.command = {
+      title: "",
+      command: "arcad-afs-for-ibm-i.show.server",
+      arguments: [this]
+    };
+  }
+
+  show() {
+    openShowArcadInstanceEditor(this.instance);
   }
 }
 
@@ -438,7 +449,7 @@ export function initializeAFSBrowser(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("arcad-afs-for-ibm-i.start.server", (server: AFSServerItem | JettyJobItem) => server.start()),
     vscode.commands.registerCommand("arcad-afs-for-ibm-i.debug.server", (server: AFSServerItem) => server.start(true)),
     vscode.commands.registerCommand("arcad-afs-for-ibm-i.stop.server", (server: AFSServerItem | JettyJobItem) => server.stop()),
-    vscode.commands.registerCommand("arcad-afs-for-ibm-i.show.server", (server: AFSServerItem | JettyJobItem) => server.show()),
+    vscode.commands.registerCommand("arcad-afs-for-ibm-i.show.server", (server: AFSServerItem | JettyJobItem | ArcadInstanceItem) => server.show()),
     vscode.commands.registerCommand("arcad-afs-for-ibm-i.edit.server", (server: AFSServerItem) => server.edit()),
     vscode.commands.registerCommand("arcad-afs-for-ibm-i.delete.server", (server: AFSServerItem | JettyWrapperItem) => server.delete()),
     vscode.commands.registerCommand("arcad-afs-for-ibm-i.open.logs.server", async (serverItem: AFSServerItem | JettyWrapperItem) => {


### PR DESCRIPTION
This PR adds an `ARCAD instances` node to the ARCAD servers browser. It lists all the ARCAD instances found on the IBM i and allows to display its licenses.

![arcad_instances](https://github.com/ARCAD-Software/arcad-ibmi-servers/assets/11096890/e93daa90-8df5-403f-b7a8-a64f656ee94c)

![arcad_instance](https://github.com/ARCAD-Software/arcad-ibmi-servers/assets/11096890/962cf232-e320-47b0-8000-edb5fa8b0f42)

