### PR TITLE
Fixed ARCAD Server iasp value interpretation

### DIFF
--- a/src/dao/arcadDAO.ts
+++ b/src/dao/arcadDAO.ts
@@ -31,7 +31,7 @@ export namespace ArcadDAO {
         code,
         text: String(instance.INS_CTXT).trim(),
         library,
-        iasp: instance.INS_NASPNB && instance.INS_NASPNB !== '1' ? String(instance.INS_NASPNB).trim() : undefined,
+        iasp: instance.INS_NASPNB && instance.INS_NASPNB !== 1 ? String(instance.INS_NASPNB).trim() : undefined,
         version
       });
     }


### PR DESCRIPTION
This PR fixes the ARCAD Servers iasp value `1` that was not correctly interpreted as `no iasp`.