### PR TITLE
Use `Code for i` subscribe instead of onEvent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "axios": "^1.7.3"
       },
       "devDependencies": {
-        "@halcyontech/vscode-ibmi-types": "^2.11",
+        "@halcyontech/vscode-ibmi-types": "^2.12",
         "@types/node": "18.x",
         "@types/vscode": "1.80.0",
         "@typescript-eslint/eslint-plugin": "^6.9.0",
@@ -497,9 +497,9 @@
       }
     },
     "node_modules/@halcyontech/vscode-ibmi-types": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@halcyontech/vscode-ibmi-types/-/vscode-ibmi-types-2.11.0.tgz",
-      "integrity": "sha512-CCk/9rihuEeO3OK9FcHBtEplmOqX0wgYmnVHaLYdsWwmc7M4PYAf5gqwV2pzn0JJYW1LP/NX1oLc1vwKTm4x7g==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@halcyontech/vscode-ibmi-types/-/vscode-ibmi-types-2.12.1.tgz",
+      "integrity": "sha512-28OUrucjb98bo28KrEbw0xMr00BZ9RWLbXhAW4kapcZ7CNhrOIIZg/LlP+LjVzfJ97i+XyhdCF1es2+2oFMdXg==",
       "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -368,7 +368,7 @@
     "nls": "npx @vscode/l10n-dev export --outDir ./l10n ./src"
   },
   "devDependencies": {
-    "@halcyontech/vscode-ibmi-types": "^2.11",
+    "@halcyontech/vscode-ibmi-types": "^2.12",
     "@types/node": "18.x",
     "@types/vscode": "1.80.0",
     "@typescript-eslint/eslint-plugin": "^6.9.0",

--- a/src/code4i.ts
+++ b/src/code4i.ts
@@ -3,13 +3,14 @@ import vscode, { l10n } from "vscode";
 
 let codeForIBMi: CodeForIBMi;
 export namespace Code4i {
-
-  export async function initialize() {
+  let subscribe : (event:IBMiEvent, name:string, func:Function) => void;
+  export async function initialize(context: vscode.ExtensionContext) {
     const codeForIBMiExtension = vscode.extensions.getExtension<CodeForIBMi>('halcyontechltd.code-for-ibmi');
     if (codeForIBMiExtension) {
       codeForIBMi = codeForIBMiExtension.isActive ? codeForIBMiExtension.exports : await codeForIBMiExtension.activate();
       console.log(vscode.l10n.t("The extension 'arcad-afs-for-ibm-i' is now active!"));
-      codeForIBMi.instance.onEvent("connected", checkJava);
+      subscribe = (event:IBMiEvent, name:string, func:Function) => codeForIBMi.instance.subscribe(context, event, name, func);
+      subscribe("connected", "Check Java version", checkJava);
     }
     else {
       throw new Error(vscode.l10n.t("The extension 'arcad-afs-for-ibm-i' requires the 'halcyontechltd.code-for-ibmi' extension to be active!"));
@@ -45,8 +46,8 @@ export namespace Code4i {
     return codeForIBMi.instance.getContent().checkObject({ library, name, type });
   }
 
-  export function onEvent(event: IBMiEvent, todo: Function) {
-    codeForIBMi.instance.onEvent(event, todo);
+  export function onEvent(event: IBMiEvent, name:string, todo: Function) {
+    subscribe(event, name, todo);
   }
 
   export function customUI() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import { initializeAFSBrowser } from './views/serversBrowser';
 
 
 export async function activate(context: vscode.ExtensionContext) {
-	await Code4i.initialize();
+	await Code4i.initialize(context);
 	initializeAFSBrowser(context);
 	context.subscriptions.push(
 		vscode.commands.registerCommand("arcad-afs-for-ibm-i.open.online.help", () => vscode.commands.executeCommand("vscode.open","https://arcad-software.github.io/arcad-ibmi-servers"))

--- a/src/views/serversBrowser.ts
+++ b/src/views/serversBrowser.ts
@@ -20,7 +20,7 @@ class AFSServerBrowser implements vscode.TreeDataProvider<ServerBrowserItem> {
   readonly onDidChangeTreeData = this.emitter.event;
 
   constructor() {
-    Code4i.onEvent("connected", () => this.reload());
+    Code4i.onEvent("connected", "Reload AFS Servers view", () => this.reload());
   }
 
   refresh(target?: ServerBrowserItem) {


### PR DESCRIPTION
Since `Code for i` v2.12, the `onEvent` function is deprecated and `subscribe` must be used instead to register functions executed when connecting/disconnecting.