### PR TITLE
Fixed AFS queries

### DIFF
--- a/src/dao/afsDAO.ts
+++ b/src/dao/afsDAO.ts
@@ -26,7 +26,7 @@ export namespace AFSServerDAO {
         javaHome: String(row.AFS_JAVA_HOME).trim(),
         jobName: String(row.AFS_JOBNAME).trim(),
         jobUser: String(row.AFS_JOBUSER).trim(),
-        jobNumber: String(row.AFS_JOBNUMBER).trim(),
+        jobNumber: String(row.AFS_JOBNUMBER).trim().padStart(6, '0'),
         running: Boolean(row.V_JOB_STATUS === '*ACTIVE'),
         jobStatus: row.V_ACTIVE_JOB_STATUS ? String(row.V_ACTIVE_JOB_STATUS).trim() : undefined,
         configuration: await loadConfiguration(String(row.AFS_IFSPATH).trim())

--- a/src/dao/afsDAO.ts
+++ b/src/dao/afsDAO.ts
@@ -9,7 +9,7 @@ export namespace AFSServerDAO {
 
   export async function listServers(library: string) {
     const rows = (await Code4i.runSQL(`Select * From ${library}.AFSSERVERS ` +
-      `Cross Join Table(QSYS2.GET_JOB_INFO(AFS_JOBNUMBER || '/' || AFS_JOBUSER || '/' ||AFS_JOBNAME)) ` +
+      `Cross Join Table(QSYS2.GET_JOB_INFO(AFS_JOBNUMBER concat '/' concat AFS_JOBUSER concat '/' concat AFS_JOBNAME)) ` +
       `Order By AFS_NAME For fetch only`)
     );
 

--- a/src/dao/jettyDAO.ts
+++ b/src/dao/jettyDAO.ts
@@ -19,7 +19,7 @@ export namespace JettyDAO {
       ),
       JOBINFO As (
         Select * From JETTYJOB 
-        Cross Join Table(QSYS2.GET_JOB_INFO(JOB_NUMBER || '/' || JOB_USER || '/' || JOB_NAME))
+        Cross Join Table(QSYS2.GET_JOB_INFO(JOB_NUMBER concat '/' concat JOB_USER concat '/' concat JOB_NAME))
       )
       Select * from JOBINFO`));
 


### PR DESCRIPTION
This PR fixes the following issues:
- AFS servers listing would fail because of encoding issues (i.e. using `||` instead of `concat` could break the query depending on the user's CCSID).
- Opening an AFS server detail would not work if its job number started with one or more 0.