### PR TITLE
Add a user setting to restart servers after update

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,29 @@
   "main": "./dist/extension.js",
   "l10n": "./l10n",
   "contributes": {
-    "configuration": [],
+    "configuration": [
+      {
+        "title": "ARCAD-Servers Manager",
+        "properties": {
+          "arcadServers.restartAfterUpdate":{
+            "type": "string",
+						"enum": [
+							"Yes",
+							"No",
+							"Ask"
+						],
+						"enumDescriptions": [
+							"%restart.yes%",
+							"%restart.no%",
+							"%restart.ask%"
+						],
+						"description": "%restartAfterUpdate%",
+						"default": "Ask",
+						"order": 10
+          }
+        }
+      }
+    ],
     "commands": [
       {
         "command": "arcad-afs-for-ibm-i.refresh",

--- a/package.nls.json
+++ b/package.nls.json
@@ -14,11 +14,15 @@
   "open.http.config": "HTTP",
   "open.https.config": "HTTPS",
   "open.logs": "Open logs",
+  "open.online.help": "Open online help",
   "refresh": "Refresh",
   "reload": "Reload available installations",
+  "restart.ask": "Show a dialog giving the option to restart servers after an update",
+  "restart.no": "Never restart servers after an update",
+  "restart.yes": "Always restart servers after an update",
+  "restartAfterUpdate": "Defines if a server must be restarted after it has been updated",
   "show": "Show server information",
   "start": "Start",
   "stop": "Stop",
-  "update": "Update",
-  "open.online.help":"Open online help"
+  "update": "Update"
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,0 +1,11 @@
+import vscode from "vscode";
+
+export namespace Configuration {
+	function getConfiguration() {
+		return vscode.workspace.getConfiguration('arcadServers');
+	}
+
+	export function getPostUpdateAction() {
+		return getConfiguration().get<"Yes" | "No" | "Ask">('restartAfterUpdate', "Ask");
+	}
+}

--- a/src/dao/commonDAO.ts
+++ b/src/dao/commonDAO.ts
@@ -1,5 +1,6 @@
 import vscode, { l10n } from "vscode";
 import { Code4i } from "../code4i";
+import { Configuration } from "../configuration";
 import { InstallationProperties } from "../types";
 
 export namespace CommonDAO {
@@ -64,5 +65,24 @@ export namespace CommonDAO {
       }
     });
     return props;
-  }  
+  }
+
+  export function postUpdateRestart(servernName: string, startFunction: Function) {
+    switch (Configuration.getPostUpdateAction()) {
+      case "Yes":
+        startFunction();
+        break;
+
+      case "Ask":
+        vscode.window.showInformationMessage(l10n.t("Do you want to restart {0} ?", servernName), l10n.t("Restart"))
+          .then(restart => {
+            if (restart) {
+              startFunction();
+            }
+          });
+        break;
+
+      default: //Do nothing
+    }
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	await Code4i.initialize(context);
 	initializeAFSBrowser(context);
 	context.subscriptions.push(
-		vscode.commands.registerCommand("arcad-afs-for-ibm-i.open.online.help", () => vscode.commands.executeCommand("vscode.open","https://arcad-software.github.io/arcad-ibmi-servers"))
+		vscode.commands.registerCommand("arcad-afs-for-ibm-i.open.online.help", () => vscode.commands.executeCommand("vscode.open", "https://arcad-software.github.io/arcad-ibmi-servers"))
 	);
 }
 


### PR DESCRIPTION
Resolves #30

This PR adds a user setting that lets the user defines if a server should be restarted after an update.
![Code_tJlZTCWTYS](https://github.com/user-attachments/assets/c36c523a-9135-4b19-a0fd-ce6979e64c9c)

Possible values are:
- `Yes`: always restart after an update
- `No`: never restart after an update
- `Ask`: show a prompt with a `Restart` action