### PR TITLE
Replaced `codefori.makeId` with `Crypto.randomUUID`

### DIFF
--- a/src/code4i.ts
+++ b/src/code4i.ts
@@ -1,4 +1,5 @@
 import { CodeForIBMi, IBMiEvent, OpenEditableOptions } from "@halcyontech/vscode-ibmi-types";
+import Crypto from "crypto";
 import vscode, { l10n } from "vscode";
 
 let codeForIBMi: CodeForIBMi;
@@ -55,7 +56,7 @@ export namespace Code4i {
   }
 
   export function makeId() {
-    return codeForIBMi.tools.makeid();
+    return Crypto.randomUUID();
   }
 
   export function open(path: string, options?: OpenEditableOptions) {


### PR DESCRIPTION
The Code for IBM i API changed and using the `Tools.makeId` function failed because calling it would result in a crash (`makeId is not function`).

The extension now uses `Crypto.randomUUID` to generate a random string.